### PR TITLE
Show top dates by default in availability grid (#71)

### DIFF
--- a/app/app/components/DoodleView.tsx
+++ b/app/app/components/DoodleView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { isDateInPastLocal, getTodayDateStringLocal } from "../lib/dateUtils";
 import { CheckIcon } from "@heroicons/react/24/outline";
+import { Button } from "./ui";
 
 interface DateVote {
   date_suggestion_id: number;
@@ -25,6 +26,7 @@ interface DoodleViewProps {
 export function DoodleView({ dateSuggestions, dateVotes, currentUserId }: DoodleViewProps) {
   // Only render on client-side to use local timezone consistently
   const [isMounted, setIsMounted] = useState(false);
+  const [showAll, setShowAll] = useState(false);
 
   useEffect(() => {
     setIsMounted(true);
@@ -80,9 +82,29 @@ export function DoodleView({ dateSuggestions, dateVotes, currentUserId }: Doodle
     return null;
   }
 
+  // Determine the top 2 distinct vote counts to show by default
+  const distinctCounts = [...new Set(votedDates.map(d => dateVoteCounts.get(d.suggested_date) || 0))]
+    .sort((a, b) => b - a);
+  const topTwoCounts = new Set(distinctCounts.slice(0, 2));
+  const popularDates = votedDates.filter(d => topTwoCounts.has(dateVoteCounts.get(d.suggested_date) || 0));
+  const hasHiddenDates = popularDates.length < votedDates.length;
+
+  const displayedDates = showAll ? votedDates : popularDates;
+
   return (
     <div className="mt-6">
-      <h4 className="text-sm font-semibold text-foreground mb-3">Availability Grid</h4>
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-semibold text-foreground">Availability Grid</h4>
+        {hasHiddenDates && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowAll(v => !v)}
+          >
+            {showAll ? `Show top dates (${popularDates.length})` : `Show all dates (${votedDates.length})`}
+          </Button>
+        )}
+      </div>
       <div className="overflow-x-auto">
         <table className="min-w-full border-collapse">
           <thead>
@@ -90,7 +112,7 @@ export function DoodleView({ dateSuggestions, dateVotes, currentUserId }: Doodle
               <th className="border border-border bg-muted px-3 py-2 text-left text-xs font-medium text-muted-foreground">
                 Name
               </th>
-              {votedDates.map(date => {
+              {displayedDates.map(date => {
                 // Parse date as local (not UTC) to avoid timezone shifts
                 const [year, month, day] = date.suggested_date.split('-').map(Number);
                 const localDate = new Date(year, month - 1, day);
@@ -124,7 +146,7 @@ export function DoodleView({ dateSuggestions, dateVotes, currentUserId }: Doodle
           <tbody>
             {uniqueUsers.map(user => {
               const userVotes = voteMap.get(user.id) || new Set();
-              const voteCount = votedDates.filter(d => userVotes.has(d.suggested_date)).length;
+              const voteCount = displayedDates.filter(d => userVotes.has(d.suggested_date)).length;
 
               return (
                 <tr key={user.id} className={user.id === currentUserId ? 'bg-blue-50 dark:bg-blue-900/30' : ''}>
@@ -134,7 +156,7 @@ export function DoodleView({ dateSuggestions, dateVotes, currentUserId }: Doodle
                       <span className="ml-1 text-[10px] text-blue-600 dark:text-blue-400">(you)</span>
                     )}
                   </td>
-                  {votedDates.map(date => (
+                  {displayedDates.map(date => (
                     <td
                       key={date.id}
                       className={`border border-border text-center ${
@@ -158,7 +180,7 @@ export function DoodleView({ dateSuggestions, dateVotes, currentUserId }: Doodle
               <td className="border border-border px-3 py-2 text-xs font-semibold text-foreground">
                 Total Votes
               </td>
-              {votedDates.map(date => (
+              {displayedDates.map(date => (
                 <td
                   key={date.id}
                   className="border border-border px-3 py-2 text-center text-xs font-semibold text-foreground"

--- a/app/app/components/DoodleView.tsx
+++ b/app/app/components/DoodleView.tsx
@@ -146,7 +146,7 @@ export function DoodleView({ dateSuggestions, dateVotes, currentUserId }: Doodle
           <tbody>
             {uniqueUsers.map(user => {
               const userVotes = voteMap.get(user.id) || new Set();
-              const voteCount = displayedDates.filter(d => userVotes.has(d.suggested_date)).length;
+              const voteCount = votedDates.filter(d => userVotes.has(d.suggested_date)).length;
 
               return (
                 <tr key={user.id} className={user.id === currentUserId ? 'bg-blue-50 dark:bg-blue-900/30' : ''}>


### PR DESCRIPTION
## Summary

- Filters the DoodleView availability grid to show only dates with the top two distinct vote counts by default
- All voter rows remain visible regardless of which dates they voted for
- A "Show all dates (N)" toggle button appears only when lower-ranked dates are hidden; clicking again collapses back to "Show top dates (N)"

Closes #71

## Test plan

- [ ] With an active poll that has dates spanning at least 3 distinct vote counts, verify only the top two tiers of dates appear in the grid by default
- [ ] Verify all voters still appear as rows even if they didn't vote for any top dates
- [ ] Click "Show all dates" — confirm all voted dates appear
- [ ] Click "Show top dates" — confirm it collapses back
- [ ] When all dates share the same vote count (or only 1-2 distinct counts exist), verify the toggle button does not appear
- [ ] Run `npm run typecheck` and `npm run test:run` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)