### PR TITLE
Use virtual:react-router/server-build for Worker entry — fixes dev rendering

### DIFF
--- a/app/workers/app.ts
+++ b/app/workers/app.ts
@@ -2,8 +2,6 @@
 
 import type { MessageBatch } from "@cloudflare/workers-types";
 import { createRequestHandler } from "react-router";
-// @ts-expect-error — generated build output has no type declarations
-import * as build from "../build/server/index.js";
 import {
   type EventEmailQueueMessage,
   processEventEmailQueueBatch,
@@ -12,6 +10,15 @@ import {
 import { maybeEnsureResendEmailSetup } from "../app/lib/resend-setup.server";
 import { sendScheduledSmsReminders } from "../app/lib/sms.server";
 import type { CloudflareEnv } from "../app/env";
+
+// In dev, Vite resolves the virtual module to live source so HMR-aware asset
+// URLs are served. In prod, the `v8_viteEnvironmentApi` build flow doesn't
+// emit `build/client/.vite/manifest.json`, so the virtual server-build can't
+// be generated — fall back to the static build output instead.
+const build = import.meta.env.DEV
+  ? await import("virtual:react-router/server-build")
+  : // @ts-expect-error — generated build output has no type declarations
+    await import("../build/server/index.js");
 
 const requestHandler = createRequestHandler(build, "production");
 


### PR DESCRIPTION
## Summary
The Worker entry imports `../build/server/index.js` directly, bypassing the virtual-module mechanism the React Router + Cloudflare Vite plugin pair provides. In dev, this means the Worker serves prod-built HTML referencing hashed asset URLs that Vite's dev server doesn't resolve — every page renders without styling.

The natural fix is to swap to `virtual:react-router/server-build`, but in this repo that breaks `npm run build`. The PR resolves it by selecting the import per environment.

## The bug
Visit any route in `npm run dev` and the served HTML contains references like:

```html
<link rel="stylesheet" href="/assets/root-Bs58Piyt.css">
```

`GET /assets/root-Bs58Piyt.css` returns 404 — and the body of the 404 is the React Router 404 page, meaning the request reached the Worker rather than the asset binding. Vite serves transformed source modules at different URLs (`/@react-router/critical.css?...`), but with the static import the build object is the prod build's manifest with hash names baked in.

## Root cause
`app/workers/app.ts:5-6`:

```ts
// @ts-expect-error — generated build output has no type declarations
import * as build from "../build/server/index.js";
```

This is a literal file import. In dev, neither `@react-router/dev` nor `@cloudflare/vite-plugin` can intercept it to swap in the live module graph.

## Why the simpler swap doesn't work in this repo
The standard pattern is to import the virtual module:

```ts
import * as build from "virtual:react-router/server-build";
```

In a typical React Router 7 + Cloudflare Vite plugin setup, this resolves to live source in dev and the static build in prod. But this repo enables `future.v8_viteEnvironmentApi: true` in `react-router.config.ts`, which changes the build flow:

1. The React Router build emits `build/server/index.js` and `build/server/.vite/manifest.json`.
2. The Cloudflare plugin's `meatup_club` environment then bundles the Worker entry.
3. **`build/client/.vite/manifest.json` is never emitted** — the client bundle is delegated to step 2.

When step 2 sees the virtual import, the React Router plugin tries to generate the server-manifest for it. That generator (`generateReactRouterManifestsForBuild` in `node_modules/@react-router/dev/dist/vite.js:3245-3248`) hardcodes a read from `build/client/.vite/manifest.json` and fails with `ENOENT`. `npm run build` aborts.

## Fix
Select the import per environment in `app/workers/app.ts`:

```ts
const build = import.meta.env.DEV
  ? await import("virtual:react-router/server-build")
  : // @ts-expect-error — generated build output has no type declarations
    await import("../build/server/index.js");
```

Vite replaces `import.meta.env.DEV` at build time (`true` in dev, `false` in prod), so Rollup dead-code-eliminates the inactive branch in each mode. In dev the virtual module gives Vite's live module graph; in prod the static-file import preserves the existing build behavior.

## Verification
- `npm run typecheck` — clean.
- `npm run test:run` — 596/596 pass.
- `npm run build` — completes successfully. `dist/meatup_club/` populates; `grep -c "virtual:react-router" dist/meatup_club/**/*.js` returns `0`, confirming the dev branch is stripped from the prod bundle.
- `npm run dev` then visit `http://localhost:5173/` — page renders fully styled.

## Production impact
The bundle layout is slightly different. Where main produces a single `dist/meatup_club/index.js` (~2.1 MB), this produces a 68 kB worker entry that lazy-loads two chunks (`assets/server.edge-*.js` ~777 kB, `assets/index-*.js` ~1.3 MB) via the dynamic `await import("../build/server/index.js")`. Total bytes equivalent. `wrangler.json` already declares `rules: [{type: "ESModule", globs: ["**/*.js","**/*.mjs"]}]`, so all chunks deploy correctly. Top-level await is supported on the configured `compatibility_date = "2025-12-24"` with `nodejs_compat`.

## Test plan
- [ ] `npm run dev` — visit a few routes, confirm CSS loads (no `/assets/*.css` 404s in the dev server log).
- [ ] `npm run build` succeeds.
- [ ] `npm run test:run` passes.
- [ ] After merge + deploy: `https://meatup.club/` renders identically to before.

Closes #152