### PR TITLE
[codex] Add local dev auth bypass

### DIFF
--- a/app/.dev.vars.example
+++ b/app/.dev.vars.example
@@ -1,0 +1,6 @@
+# Optional local-only auth bypass. Copy this file to `.dev.vars` and set the
+# email to a user that exists in your local D1 database.
+#
+# This is intentionally for `npm run dev` on localhost only. Do not configure
+# this variable in Cloudflare, Terraform, GitHub Actions, or production secrets.
+# DEV_AUTH_BYPASS_EMAIL=dev@localhost

--- a/app/.dev.vars.example
+++ b/app/.dev.vars.example
@@ -1,6 +1,0 @@
-# Optional local-only auth bypass. Copy this file to `.dev.vars` and set the
-# email to a user that exists in your local D1 database.
-#
-# This is intentionally for `npm run dev` on localhost only. Do not configure
-# this variable in Cloudflare, Terraform, GitHub Actions, or production secrets.
-# DEV_AUTH_BYPASS_EMAIL=dev@localhost

--- a/app/.env.example
+++ b/app/.env.example
@@ -11,6 +11,10 @@ NODE_ENV=development
 # App timezone (IANA name, e.g. America/Chicago)
 APP_TIMEZONE=America/New_York
 
+# Optional local-only auth bypass. Set to the email of a user that exists in
+# your local D1 database to skip Google OAuth on localhost during `npm run dev`.
+# DEV_AUTH_BYPASS_EMAIL=dev@localhost
+
 # Twilio SMS
 TWILIO_ACCOUNT_SID=your-twilio-account-sid
 TWILIO_AUTH_TOKEN=your-twilio-auth-token

--- a/app/README.md
+++ b/app/README.md
@@ -87,13 +87,9 @@ A quarterly steakhouse meetup club app built with React Router 7, Cloudflare Pag
 
 ### Optional local auth bypass
 
-To skip Google OAuth during local UI work, copy `.dev.vars.example` to
-`.dev.vars` and set `DEV_AUTH_BYPASS_EMAIL` to a user that exists in your local
-D1 database:
-
-```bash
-cp .dev.vars.example .dev.vars
-```
+To skip Google OAuth during local UI work, add `DEV_AUTH_BYPASS_EMAIL` to the
+same `.env` file used for `SESSION_SECRET` and the Google OAuth values. Set it
+to a user that exists in your local D1 database:
 
 ```env
 DEV_AUTH_BYPASS_EMAIL=dev@localhost
@@ -105,9 +101,10 @@ Seed a local user for that email if needed:
 npx wrangler d1 execute meatup-club-db --local --command "INSERT OR IGNORE INTO users (email, name, status, is_admin) VALUES ('dev@localhost', 'Local Dev', 'active', 1)"
 ```
 
-Restart `npm run dev` after changing `.dev.vars`. Do not configure
+Restart `npm run dev` after changing `.env`. Do not configure
 `DEV_AUTH_BYPASS_EMAIL` in Cloudflare, Terraform, GitHub Actions, or production
-secrets.
+secrets. Cloudflare local development should use either `.env` or `.dev.vars`,
+not both; this project documents `.env` for local setup.
 
 ## Database Schema
 

--- a/app/README.md
+++ b/app/README.md
@@ -85,6 +85,30 @@ A quarterly steakhouse meetup club app built with React Router 7, Cloudflare Pag
 
    Visit http://localhost:5173
 
+### Optional local auth bypass
+
+To skip Google OAuth during local UI work, copy `.dev.vars.example` to
+`.dev.vars` and set `DEV_AUTH_BYPASS_EMAIL` to a user that exists in your local
+D1 database:
+
+```bash
+cp .dev.vars.example .dev.vars
+```
+
+```env
+DEV_AUTH_BYPASS_EMAIL=dev@localhost
+```
+
+Seed a local user for that email if needed:
+
+```bash
+npx wrangler d1 execute meatup-club-db --local --command "INSERT OR IGNORE INTO users (email, name, status, is_admin) VALUES ('dev@localhost', 'Local Dev', 'active', 1)"
+```
+
+Restart `npm run dev` after changing `.dev.vars`. Do not configure
+`DEV_AUTH_BYPASS_EMAIL` in Cloudflare, Terraform, GitHub Actions, or production
+secrets.
+
 ## Database Schema
 
 The canonical schema includes:

--- a/app/app/env.d.ts
+++ b/app/app/env.d.ts
@@ -17,6 +17,7 @@ export interface CloudflareEnv {
   TWILIO_AUTH_TOKEN?: string;
   TWILIO_FROM_NUMBER?: string;
   APP_TIMEZONE?: string;
+  DEV_AUTH_BYPASS_EMAIL?: string;
 }
 
 declare module "react-router" {

--- a/app/app/lib/auth.server.test.ts
+++ b/app/app/lib/auth.server.test.ts
@@ -23,6 +23,8 @@ vi.mock("./db.server", () => ({
   getUserByEmail: vi.fn(),
 }));
 
+const originalNodeEnv = process.env.NODE_ENV;
+
 type SessionValues = {
   userId?: number;
   email?: string;
@@ -56,6 +58,7 @@ const baseContext: {
       DB: {
         marker: string;
       };
+      DEV_AUTH_BYPASS_EMAIL?: string;
     };
   };
 } = {
@@ -98,6 +101,11 @@ describe("auth.server", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
     delete process.env.GOOGLE_CLIENT_ID;
     delete process.env.GOOGLE_CLIENT_SECRET;
   });
@@ -131,6 +139,118 @@ describe("auth.server", () => {
       "member@example.com"
     );
     expect(user).toEqual(baseUser);
+  });
+
+  it("does not use the local auth bypass when the bypass email is unset", async () => {
+    process.env.NODE_ENV = "development";
+    vi.mocked(getSession).mockResolvedValue(createMockSession() as never);
+
+    const user = await getUser(
+      createCookieRequest("http://localhost/dashboard"),
+      baseContext as never
+    );
+
+    expect(user).toBeNull();
+    expect(getUserByEmail).not.toHaveBeenCalled();
+    expect(getSession).toHaveBeenCalledWith("__session=abc");
+  });
+
+  it("does not use the local auth bypass in tests", async () => {
+    process.env.NODE_ENV = "test";
+    vi.mocked(getSession).mockResolvedValue(createMockSession() as never);
+
+    const user = await getUser(
+      createCookieRequest("http://localhost/dashboard"),
+      {
+        cloudflare: {
+          env: {
+            ...baseContext.cloudflare.env,
+            DEV_AUTH_BYPASS_EMAIL: "dev@localhost",
+          },
+        },
+      } as never
+    );
+
+    expect(user).toBeNull();
+    expect(getUserByEmail).not.toHaveBeenCalled();
+    expect(getSession).toHaveBeenCalledWith("__session=abc");
+  });
+
+  it("loads a local auth bypass user from the database on localhost", async () => {
+    process.env.NODE_ENV = "development";
+    const devUser = {
+      ...baseUser,
+      id: 1,
+      email: "dev@localhost",
+      name: "Local Dev",
+      is_admin: 1,
+    };
+    vi.mocked(getUserByEmail).mockResolvedValue(devUser as never);
+
+    const user = await getUser(
+      createCookieRequest("http://localhost/dashboard"),
+      {
+        cloudflare: {
+          env: {
+            ...baseContext.cloudflare.env,
+            DEV_AUTH_BYPASS_EMAIL: " dev@localhost ",
+          },
+        },
+      } as never
+    );
+
+    expect(user).toEqual(devUser);
+    expect(getUserByEmail).toHaveBeenCalledWith(
+      baseContext.cloudflare.env.DB,
+      "dev@localhost"
+    );
+    expect(getSession).not.toHaveBeenCalled();
+  });
+
+  it("falls through to normal auth when the local auth bypass user is missing", async () => {
+    process.env.NODE_ENV = "development";
+    vi.mocked(getUserByEmail).mockResolvedValue(null as never);
+    vi.mocked(getSession).mockResolvedValue(createMockSession() as never);
+
+    const user = await getUser(
+      createCookieRequest("http://localhost/dashboard"),
+      {
+        cloudflare: {
+          env: {
+            ...baseContext.cloudflare.env,
+            DEV_AUTH_BYPASS_EMAIL: "dev@localhost",
+          },
+        },
+      } as never
+    );
+
+    expect(user).toBeNull();
+    expect(getUserByEmail).toHaveBeenCalledWith(
+      baseContext.cloudflare.env.DB,
+      "dev@localhost"
+    );
+    expect(getSession).toHaveBeenCalledWith("__session=abc");
+  });
+
+  it("does not use the local auth bypass outside localhost", async () => {
+    process.env.NODE_ENV = "development";
+    vi.mocked(getSession).mockResolvedValue(createMockSession() as never);
+
+    const user = await getUser(
+      createCookieRequest("https://meatup.club/dashboard"),
+      {
+        cloudflare: {
+          env: {
+            ...baseContext.cloudflare.env,
+            DEV_AUTH_BYPASS_EMAIL: "dev@localhost",
+          },
+        },
+      } as never
+    );
+
+    expect(user).toBeNull();
+    expect(getUserByEmail).not.toHaveBeenCalled();
+    expect(getSession).toHaveBeenCalledWith("__session=abc");
   });
 
   it("redirects unauthenticated requests to login", async () => {

--- a/app/app/lib/auth.server.ts
+++ b/app/app/lib/auth.server.ts
@@ -38,11 +38,32 @@ export type GoogleUserInfo = {
   locale?: string;
 };
 
+function getLocalDevAuthBypassEmail(context: AppLoadContext) {
+  if (!import.meta.env.DEV || process.env.NODE_ENV === "test") {
+    return null;
+  }
+
+  return context.cloudflare.env.DEV_AUTH_BYPASS_EMAIL?.trim() || null;
+}
+
+function isLocalhostRequest(request: Request) {
+  return new URL(request.url).hostname === "localhost";
+}
+
 // Get current user from session
 export async function getUser(
   request: Request,
   context: AppLoadContext
 ): Promise<AuthUser | null> {
+  const bypassEmail = getLocalDevAuthBypassEmail(context);
+
+  if (bypassEmail && isLocalhostRequest(request)) {
+    const user = await getUserByEmail(context.cloudflare.env.DB, bypassEmail);
+    if (user) {
+      return user as AuthUser;
+    }
+  }
+
   const session = await getSession(request.headers.get("Cookie"));
   const userId = session.get("userId");
   const email = session.get("email");


### PR DESCRIPTION
## Summary

- Implement an opt-in `DEV_AUTH_BYPASS_EMAIL` flow.
- Gate the bypass behind Vite dev mode, non-test `NODE_ENV`, and `localhost`, then load the user from local D1 instead of returning a stub.
- Document local `.env` setup and add regression coverage for bypass guard behavior.

Closes #162.

## Validation

- `npm run test:run`
- `npm run typecheck`
- `npm run build`