### PR TITLE
Fix closing polls without votes

### DIFF
--- a/app/app/routes/dashboard.admin.polls.action-coverage.test.ts
+++ b/app/app/routes/dashboard.admin.polls.action-coverage.test.ts
@@ -234,6 +234,26 @@ describe("dashboard.admin.polls action coverage", () => {
     expect(result).toEqual({ error: "Poll is not active or does not exist" });
   });
 
+  it("closes an active poll without winners or event creation", async () => {
+    const db = createMockDb();
+
+    const response = await action({
+      request: createRequest({ _action: "close", poll_id: "1" }),
+      context: { cloudflare: { env: { DB: db }, ctx: { waitUntil: vi.fn() } } } as never,
+      params: {},
+    } as never);
+
+    expect((response as Response).status).toBe(302);
+    expect((response as Response).headers.get("Location")).toBe("/dashboard/admin/polls");
+    expect(db.batch).not.toHaveBeenCalled();
+    expect(db.runCalls).toContainEqual(
+      expect.objectContaining({
+        sql: "UPDATE polls SET status = 'closed', closed_by = ?, closed_at = CURRENT_TIMESTAMP, winning_restaurant_id = ?, winning_date_id = ?, created_event_id = ? WHERE id = ? AND status = 'active'",
+        bindArgs: [1, null, null, null, 1],
+      })
+    );
+  });
+
   it("requires winning selections when creating an event", async () => {
     const result = await action({
       request: createRequest({

--- a/app/app/routes/dashboard.admin.polls.route-ui.test.tsx
+++ b/app/app/routes/dashboard.admin.polls.route-ui.test.tsx
@@ -271,6 +271,42 @@ describe("dashboard.admin.polls loader and UI", () => {
     );
   });
 
+  it("renders a close-only form when an active poll has no winners", () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard/admin/polls"]}>
+        <AdminPollsPage
+          {...(({
+            loaderData: {
+              activePoll: {
+                id: 10,
+                title: "June Poll",
+                created_at: "2026-05-01T00:00:00.000Z",
+              },
+              topRestaurant: null,
+              topDate: null,
+              allRestaurants: [],
+              allDates: [],
+              closedPolls: [],
+            },
+            actionData: undefined,
+          } as unknown) as Route.ComponentProps)}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("June Poll")).toBeInTheDocument();
+    expect(screen.getByTestId("vote-leaders-card")).toHaveTextContent("no-restaurant");
+    expect(screen.getByText("No winners yet. Closing this poll will not create an event.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close Poll Without Winners" })).toBeInTheDocument();
+    expect(document.querySelector('input[name="_action"]')).toHaveValue("close");
+    expect(document.querySelector('input[name="poll_id"]')).toHaveValue("10");
+    expect(document.querySelector('select[name="winning_restaurant_id"]')).toBeNull();
+    expect(document.querySelector('select[name="winning_date_id"]')).toBeNull();
+    expect(screen.queryByLabelText("Create event from winners")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Send calendar invites to all members")).not.toBeInTheDocument();
+    expect(document.querySelector('input[name="event_time"]')).toBeNull();
+  });
+
   it("renders the create-poll form and empty history state when no poll is active", () => {
     render(
       <MemoryRouter initialEntries={["/dashboard/admin/polls"]}>

--- a/app/app/routes/dashboard.admin.polls.route-ui.test.tsx
+++ b/app/app/routes/dashboard.admin.polls.route-ui.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminPollsPage, { loader } from "./dashboard.admin.polls";
 import type { Route } from "./+types/dashboard.admin.polls";
 import { requireActiveUser } from "../lib/auth.server";
@@ -305,6 +305,151 @@ describe("dashboard.admin.polls loader and UI", () => {
     expect(screen.queryByLabelText("Create event from winners")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Send calendar invites to all members")).not.toBeInTheDocument();
     expect(document.querySelector('input[name="event_time"]')).toBeNull();
+  });
+
+  describe("close poll confirmation dialog", () => {
+    let confirmMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      confirmMock = vi.fn().mockReturnValue(true);
+      vi.stubGlobal("confirm", confirmMock);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    function getCloseForm(): HTMLFormElement {
+      const closeAction = document.querySelector(
+        'input[name="_action"][value="close"]'
+      );
+      const form = closeAction?.closest("form");
+      if (!(form instanceof HTMLFormElement)) {
+        throw new Error("close form not found");
+      }
+      return form;
+    }
+
+    function renderWithLeaders() {
+      return render(
+        <MemoryRouter initialEntries={["/dashboard/admin/polls"]}>
+          <AdminPollsPage
+            {...(({
+              loaderData: {
+                activePoll: {
+                  id: 10,
+                  title: "June Poll",
+                  created_at: "2026-05-01T00:00:00.000Z",
+                },
+                topRestaurant: {
+                  id: 100,
+                  name: "Prime Steakhouse",
+                  address: "123 Main St",
+                  vote_count: 4,
+                },
+                topDate: {
+                  id: 200,
+                  suggested_date: "2026-06-20",
+                  vote_count: 5,
+                },
+                allRestaurants: [
+                  { id: 100, name: "Prime Steakhouse", address: "123 Main St", vote_count: 4 },
+                  { id: 101, name: "Ocean Grill", address: "9 Dock St", vote_count: 2 },
+                ],
+                allDates: [
+                  { id: 200, suggested_date: "2026-06-20", vote_count: 5 },
+                  { id: 201, suggested_date: "2026-06-27", vote_count: 3 },
+                ],
+                closedPolls: [],
+              },
+              actionData: undefined,
+            } as unknown) as Route.ComponentProps)}
+          />
+        </MemoryRouter>
+      );
+    }
+
+    function renderWithoutLeaders() {
+      return render(
+        <MemoryRouter initialEntries={["/dashboard/admin/polls"]}>
+          <AdminPollsPage
+            {...(({
+              loaderData: {
+                activePoll: {
+                  id: 10,
+                  title: "June Poll",
+                  created_at: "2026-05-01T00:00:00.000Z",
+                },
+                topRestaurant: null,
+                topDate: null,
+                allRestaurants: [],
+                allDates: [],
+                closedPolls: [],
+              },
+              actionData: undefined,
+            } as unknown) as Route.ComponentProps)}
+          />
+        </MemoryRouter>
+      );
+    }
+
+    it("confirms with a no-winner message when closing a poll without leaders", () => {
+      renderWithoutLeaders();
+
+      fireEvent.submit(getCloseForm());
+
+      expect(confirmMock).toHaveBeenCalledTimes(1);
+      const message = confirmMock.mock.calls[0][0];
+      expect(message).toContain('Close poll "June Poll" with no winner?');
+      expect(message).toContain("This cannot be undone.");
+      expect(message).not.toContain("Winning restaurant");
+      expect(message).not.toContain("event will be created");
+    });
+
+    it("confirms with winner details when closing a poll with leaders and default options", () => {
+      renderWithLeaders();
+
+      fireEvent.submit(getCloseForm());
+
+      expect(confirmMock).toHaveBeenCalledTimes(1);
+      const message = confirmMock.mock.calls[0][0];
+      expect(message).toContain('Close poll "June Poll"?');
+      expect(message).toContain("Winning restaurant: Prime Steakhouse");
+      expect(message).toContain("Winning date: formatted:2026-06-20");
+      expect(message).toContain("An event will be created at 6:00 PM.");
+      expect(message).toContain("All active members will be sent calendar invites.");
+      expect(message).toContain("This cannot be undone.");
+    });
+
+    it("reflects unchecked event creation and invite options in the confirmation", () => {
+      renderWithLeaders();
+
+      const createEventCheckbox = screen.getByLabelText("Create event from winners") as HTMLInputElement;
+      const sendInvitesCheckbox = screen.getByLabelText(
+        "Send calendar invites to all members"
+      ) as HTMLInputElement;
+      fireEvent.click(createEventCheckbox);
+      fireEvent.click(sendInvitesCheckbox);
+
+      fireEvent.submit(getCloseForm());
+
+      const message = confirmMock.mock.calls[0][0];
+      expect(message).toContain("No event will be created.");
+      expect(message).toContain("Members will not be notified.");
+      expect(message).not.toContain("An event will be created at");
+      expect(message).not.toContain("All active members will be sent");
+    });
+
+    it("prevents form submission when the admin cancels the confirmation", () => {
+      confirmMock.mockReturnValue(false);
+      renderWithoutLeaders();
+
+      const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
+      getCloseForm().dispatchEvent(submitEvent);
+
+      expect(confirmMock).toHaveBeenCalledTimes(1);
+      expect(submitEvent.defaultPrevented).toBe(true);
+    });
   });
 
   it("renders the create-poll form and empty history state when no poll is active", () => {

--- a/app/app/routes/dashboard.admin.polls.tsx
+++ b/app/app/routes/dashboard.admin.polls.tsx
@@ -1,3 +1,4 @@
+import type { FormEvent } from "react";
 import { Form, Link } from "react-router";
 import type { D1Result } from "@cloudflare/workers-types";
 import type { Route } from "./+types/dashboard.admin.polls";
@@ -397,9 +398,70 @@ export async function action({ request, context }: Route.ActionArgs) {
   return { error: 'Invalid action' };
 }
 
+function formatTime12h(time24: string): string {
+  const [hStr, mStr] = time24.split(':');
+  const h = Number(hStr);
+  const m = Number(mStr);
+  if (Number.isNaN(h) || Number.isNaN(m)) return time24;
+  const period = h >= 12 ? 'PM' : 'AM';
+  const hour12 = h % 12 || 12;
+  return `${hour12}:${m.toString().padStart(2, '0')} ${period}`;
+}
+
 export default function AdminPollsPage({ loaderData, actionData }: Route.ComponentProps) {
   const { activePoll, topRestaurant, topDate, allRestaurants, allDates, closedPolls } = loaderData;
   const canCreateEventFromWinners = Boolean(topRestaurant && topDate);
+
+  const handleCloseSubmit = (event: FormEvent<HTMLFormElement>) => {
+    if (!activePoll) return;
+    const formData = new FormData(event.currentTarget);
+    const lines: string[] = [];
+
+    if (canCreateEventFromWinners) {
+      const restaurantId = Number(formData.get('winning_restaurant_id'));
+      const dateId = Number(formData.get('winning_date_id'));
+      const restaurant = allRestaurants.find((r: any) => Number(r.id) === restaurantId);
+      const date = allDates.find((d: any) => Number(d.id) === dateId);
+      const createEvent = formData.get('create_event') === 'true';
+      const sendInvites = formData.get('send_invites') === 'true';
+      const eventTime = String(formData.get('event_time') || '18:00');
+
+      lines.push(`Close poll "${activePoll.title}"?`);
+      lines.push('');
+      lines.push(`Winning restaurant: ${restaurant?.name ?? 'Unknown'}`);
+      lines.push(
+        `Winning date: ${date
+          ? formatDateForDisplay(date.suggested_date as string, {
+              weekday: 'short',
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            })
+          : 'Unknown'}`
+      );
+      lines.push('');
+      lines.push(
+        createEvent
+          ? `An event will be created at ${formatTime12h(eventTime)}.`
+          : 'No event will be created.'
+      );
+      lines.push(
+        createEvent && sendInvites
+          ? 'All active members will be sent calendar invites.'
+          : 'Members will not be notified.'
+      );
+      lines.push('');
+      lines.push('This cannot be undone.');
+    } else {
+      lines.push(`Close poll "${activePoll.title}" with no winner?`);
+      lines.push('');
+      lines.push('This cannot be undone.');
+    }
+
+    if (!window.confirm(lines.join('\n'))) {
+      event.preventDefault();
+    }
+  };
 
   return (
     <AdminLayout>
@@ -440,7 +502,7 @@ export default function AdminPollsPage({ loaderData, actionData }: Route.Compone
           </div>
 
           {/* Close Poll Form */}
-          <Form method="post" className="bg-muted border border-border rounded-lg p-6">
+          <Form method="post" onSubmit={handleCloseSubmit} className="bg-muted border border-border rounded-lg p-6">
             <h3 className="text-lg font-semibold mb-4">Close Poll</h3>
             <input type="hidden" name="_action" value="close" />
             <input type="hidden" name="poll_id" value={activePoll.id} />

--- a/app/app/routes/dashboard.admin.polls.tsx
+++ b/app/app/routes/dashboard.admin.polls.tsx
@@ -399,6 +399,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 
 export default function AdminPollsPage({ loaderData, actionData }: Route.ComponentProps) {
   const { activePoll, topRestaurant, topDate, allRestaurants, allDates, closedPolls } = loaderData;
+  const canCreateEventFromWinners = Boolean(topRestaurant && topDate);
 
   return (
     <AdminLayout>
@@ -439,119 +440,125 @@ export default function AdminPollsPage({ loaderData, actionData }: Route.Compone
           </div>
 
           {/* Close Poll Form */}
-          {topRestaurant && topDate && (
-            <Form method="post" className="bg-muted border border-border rounded-lg p-6">
-              <h3 className="text-lg font-semibold mb-4">Close Poll</h3>
-              <input type="hidden" name="_action" value="close" />
-              <input type="hidden" name="poll_id" value={activePoll.id} />
+          <Form method="post" className="bg-muted border border-border rounded-lg p-6">
+            <h3 className="text-lg font-semibold mb-4">Close Poll</h3>
+            <input type="hidden" name="_action" value="close" />
+            <input type="hidden" name="poll_id" value={activePoll.id} />
 
-              {/* Restaurant & Date Override Selects */}
-              <div className="space-y-4 mb-6">
-                <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
-                    Restaurant
+            {canCreateEventFromWinners ? (
+              <>
+                {/* Restaurant & Date Override Selects */}
+                <div className="space-y-4 mb-6">
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">
+                      Restaurant
+                    </label>
+                    <select
+                      name="winning_restaurant_id"
+                      defaultValue={topRestaurant!.id}
+                      className="w-full px-4 py-2 border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-accent bg-card text-foreground"
+                      required
+                    >
+                      {allRestaurants.map((restaurant: any) => (
+                        <option key={restaurant.id} value={restaurant.id}>
+                          {restaurant.name} - {restaurant.vote_count} vote{restaurant.vote_count !== 1 ? 's' : ''}
+                          {restaurant.id === topRestaurant!.id ? ' (Leader)' : ''}
+                        </option>
+                      ))}
+                    </select>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Defaulted to vote leader, but you can override
+                    </p>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">
+                      Date
+                    </label>
+                    <select
+                      name="winning_date_id"
+                      defaultValue={topDate!.id}
+                      className="w-full px-4 py-2 border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-accent bg-card text-foreground"
+                      required
+                    >
+                      {allDates.map((date: any) => (
+                        <option key={date.id} value={date.id}>
+                          {formatDateForDisplay(date.suggested_date, {
+                            weekday: 'short',
+                            month: 'short',
+                            day: 'numeric',
+                            year: 'numeric',
+                          })} - {date.vote_count} vote{date.vote_count !== 1 ? 's' : ''}
+                          {date.id === topDate!.id ? ' (Leader)' : ''}
+                        </option>
+                      ))}
+                    </select>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Defaulted to vote leader, but you can override
+                    </p>
+                  </div>
+                </div>
+
+                <div className="space-y-4 mb-4">
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      name="create_event"
+                      value="true"
+                      defaultChecked
+                      className="w-4 h-4 text-accent rounded focus:ring-accent"
+                    />
+                    <span className="text-sm font-medium text-foreground">
+                      Create event from winners
+                    </span>
                   </label>
-                  <select
-                    name="winning_restaurant_id"
-                    defaultValue={topRestaurant.id}
-                    className="w-full px-4 py-2 border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-accent bg-card text-foreground"
-                    required
-                  >
-                    {allRestaurants.map((restaurant: any) => (
-                      <option key={restaurant.id} value={restaurant.id}>
-                        {restaurant.name} - {restaurant.vote_count} vote{restaurant.vote_count !== 1 ? 's' : ''}
-                        {restaurant.id === topRestaurant.id ? ' (Leader)' : ''}
-                      </option>
-                    ))}
-                  </select>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Defaulted to vote leader, but you can override
+                  <p className="text-xs text-muted-foreground mt-1 ml-6">
+                    This will create an upcoming event with the winning restaurant and date
+                  </p>
+
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      name="send_invites"
+                      value="true"
+                      defaultChecked
+                      className="w-4 h-4 text-accent rounded focus:ring-accent"
+                    />
+                    <span className="text-sm font-medium text-foreground">
+                      Send calendar invites to all members
+                    </span>
+                  </label>
+                  <p className="text-xs text-muted-foreground mt-1 ml-6">
+                    Sends personalized calendar invites to all active members
                   </p>
                 </div>
 
-                <div>
+                <div className="mb-4">
                   <label className="block text-sm font-medium text-foreground mb-2">
-                    Date
+                    Event Time
                   </label>
-                  <select
-                    name="winning_date_id"
-                    defaultValue={topDate.id}
-                    className="w-full px-4 py-2 border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-accent bg-card text-foreground"
+                  <input
+                    type="time"
+                    name="event_time"
+                    defaultValue="18:00"
+                    className="w-full px-4 py-2 border border-border rounded-md focus:ring-accent focus:border-accent"
                     required
-                  >
-                    {allDates.map((date: any) => (
-                      <option key={date.id} value={date.id}>
-                        {formatDateForDisplay(date.suggested_date, {
-                          weekday: 'short',
-                          month: 'short',
-                          day: 'numeric',
-                          year: 'numeric',
-                        })} - {date.vote_count} vote{date.vote_count !== 1 ? 's' : ''}
-                        {date.id === topDate.id ? ' (Leader)' : ''}
-                      </option>
-                    ))}
-                  </select>
+                  />
                   <p className="text-xs text-muted-foreground mt-1">
-                    Defaulted to vote leader, but you can override
+                    Time for the event (defaults to 6:00 PM)
                   </p>
                 </div>
-              </div>
+              </>
+            ) : (
+              <Alert variant="info" className="mb-4">
+                No winners yet. Closing this poll will not create an event.
+              </Alert>
+            )}
 
-              <div className="space-y-4 mb-4">
-                <label className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    name="create_event"
-                    value="true"
-                    defaultChecked
-                    className="w-4 h-4 text-accent rounded focus:ring-accent"
-                  />
-                  <span className="text-sm font-medium text-foreground">
-                    Create event from winners
-                  </span>
-                </label>
-                <p className="text-xs text-muted-foreground mt-1 ml-6">
-                  This will create an upcoming event with the winning restaurant and date
-                </p>
-
-                <label className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    name="send_invites"
-                    value="true"
-                    defaultChecked
-                    className="w-4 h-4 text-accent rounded focus:ring-accent"
-                  />
-                  <span className="text-sm font-medium text-foreground">
-                    Send calendar invites to all members
-                  </span>
-                </label>
-                <p className="text-xs text-muted-foreground mt-1 ml-6">
-                  Sends personalized calendar invites to all active members
-                </p>
-              </div>
-
-              <div className="mb-4">
-                <label className="block text-sm font-medium text-foreground mb-2">
-                  Event Time
-                </label>
-                <input
-                  type="time"
-                  name="event_time"
-                  defaultValue="18:00"
-                  className="w-full px-4 py-2 border border-border rounded-md focus:ring-accent focus:border-accent"
-                  required
-                />
-                <p className="text-xs text-muted-foreground mt-1">
-                  Time for the event (defaults to 6:00 PM)
-                </p>
-              </div>
-
-              <Button type="submit" className="w-full">
-                Close Poll & Finalize Winners
-              </Button>
-            </Form>
-          )}
+            <Button type="submit" className="w-full">
+              {canCreateEventFromWinners ? 'Close Poll & Finalize Winners' : 'Close Poll Without Winners'}
+            </Button>
+          </Form>
         </Card>
       ) : (
         <Card className="p-6 mb-8">

--- a/app/app/routes/dashboard.admin.polls.tsx
+++ b/app/app/routes/dashboard.admin.polls.tsx
@@ -18,6 +18,7 @@ import { formatDateForDisplay, formatDateTimeForDisplay, getAppTimeZone, isDateI
 import { Alert, Badge, Button, Card, PageHeader } from "../components/ui";
 import { ClipboardDocumentCheckIcon } from "@heroicons/react/24/outline";
 import { AdminLayout } from "../components/AdminLayout";
+import { confirmAction } from "../lib/confirm.client";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const user = await requireActiveUser(request, context);
@@ -458,7 +459,7 @@ export default function AdminPollsPage({ loaderData, actionData }: Route.Compone
       lines.push('This cannot be undone.');
     }
 
-    if (!window.confirm(lines.join('\n'))) {
+    if (!confirmAction(lines.join('\n'))) {
       event.preventDefault();
     }
   };

--- a/app/test/admin-polls.form-contract.test.tsx
+++ b/app/test/admin-polls.form-contract.test.tsx
@@ -330,7 +330,7 @@ describe('Admin Polls Close Form Contract', () => {
       expect(select.options[0].text).toBe('Only Restaurant');
     });
 
-    it('should not render form when no votes exist (topRestaurant is null)', async () => {
+    it('should render a close-only form when no votes exist', async () => {
       const mockLoaderData = {
         activePoll: { id: 1, title: 'Weekly Poll', status: 'active' },
         topRestaurant: null,
@@ -341,10 +341,16 @@ describe('Admin Polls Close Form Contract', () => {
       };
 
       const TestComponent = () => {
-        const { topRestaurant, topDate } = mockLoaderData;
+        const { activePoll, topRestaurant, topDate } = mockLoaderData;
 
         if (!topRestaurant || !topDate) {
-          return <div data-testid="no-votes">No votes yet - cannot close poll</div>;
+          return (
+            <form>
+              <input type="hidden" name="_action" value="close" />
+              <input type="hidden" name="poll_id" value={activePoll.id} />
+              <button type="submit">Close Poll Without Winners</button>
+            </form>
+          );
         }
 
         return <div data-testid="close-form">Close Poll Form</div>;
@@ -352,7 +358,9 @@ describe('Admin Polls Close Form Contract', () => {
 
       render(<TestComponent />);
 
-      expect(screen.getByTestId('no-votes')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Close Poll Without Winners' })).toBeInTheDocument();
+      expect(document.querySelector('input[name="_action"]')).toHaveValue('close');
+      expect(document.querySelector('input[name="poll_id"]')).toHaveValue('1');
       expect(screen.queryByTestId('close-form')).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
- The admin close-poll form was gated on `topRestaurant && topDate`, so a poll with zero votes had no submit affordance even though the action handler already supported the no-winner path.
- UI now always renders the close form. Restaurant/date selects, event-creation checkboxes, and event-time input are conditional on having leaders; the no-winner state shows an info alert and a "Close Poll Without Winners" button.
- Adds a `window.confirm` dialog before submission with a context-aware message: "with no winner" copy when leaders are absent, otherwise winning restaurant + date + whether an event will be created and members notified.

## Test plan
- [ ] Open admin polls with no votes → click close → confirm dialog says "with no winner"; cancelling aborts; confirming closes the poll.
- [ ] Open admin polls with votes → click close → dialog shows restaurant + date + event time + invites lines.
- [ ] Toggle "Create event" off → dialog says "No event will be created." and "Members will not be notified."
- [ ] Untoggle just "Send invites" → dialog says event will be created at *time* but "Members will not be notified."
- [ ] Override the restaurant/date selects → dialog reflects the override.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)