### PR TITLE
Standardize page styling via centralized CSS classes (#155)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,19 @@ CSS variables in `app.css` define a dark-first warm palette:
 - Typography: `text-display-xl/lg/md` (Cormorant Garamond display font)
 - Tailwind aliases: `meat-red` → accent, `meat-brown` → accent-strong (legacy, being removed)
 
+### Page layout conventions
+
+Every page-level structural decision is centralized in CSS classes in `app.css`. Edit the class once and every page picks up the change.
+
+- **`.page-main`** — Every `<main>` uses this. Width = `max-w-6xl` (1152px), centered, with `px-4 sm:px-6 lg:px-8 py-12`. Use it raw (`<main className="page-main">`); modifier classes like `dashboard-preview` compose alongside it (`<main className="dashboard-preview page-main">`).
+- **`.page-heading`** — Page-level h1. Used by `PageHeader`'s h1 internally; apply directly when a page can't use `PageHeader` (e.g., needs custom header layout, kicker, or fade-in wrapper).
+- **`.section-heading`** — Page-level h2 for major content sections (`text-2xl font-bold`). Margin utilities (`mb-3`, `mb-4`) compose alongside.
+- **`.page-section`** — Standard bottom margin between major page sections (`mb-8`).
+- **Section pattern** — For plain sections (no icon, no toolbar), put the h2 above the card with `mb-3`. For sections with an icon + title + description + action toolbar (Dashboard home, About content cards), keep the header strip inside the card — it's a coherent unit on its own.
+- **Page-load fade-in** — Wrap each major section with `className="dashboard-section"` and an inline `style={{ '--section-delay': 'Xms' } as CSSProperties}`. Cadence used on Dashboard, About, Admin home: header 20ms, first section 40ms, follow-on sections 150ms / 250ms / 350ms. Imports `CSSProperties` from `react`.
+
+Page widths used to drift between `max-w-7xl`, `6xl`, and `4xl`. Don't reintroduce inline width/padding overrides on `<main>` — change `.page-main` if a new width is needed everywhere.
+
 ### Voting System
 
 Restaurants are global entities. In each poll, users can vote on any restaurant (unless excluded):

--- a/app/app/app.css
+++ b/app/app/app.css
@@ -87,6 +87,56 @@ body {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   PAGE LAYOUT — single source of truth for page width, padding, headings,
+   and section rhythm. Every <main> uses .page-main; section h2s use
+   .section-heading; major content blocks use .page-section.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.page-main {
+  max-width: 72rem; /* matches Tailwind max-w-6xl */
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+@media (min-width: 640px) {
+  .page-main {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .page-main {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+}
+
+.page-heading {
+  font-family: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+  color: rgb(var(--foreground));
+}
+
+.section-heading {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 700;
+  color: rgb(var(--foreground));
+}
+
+.page-section {
+  margin-bottom: 2rem;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    STEAK LANDING PAGE
    ═══════════════════════════════════════════════════════════════════════════ */
 

--- a/app/app/components/ui/PageHeader.tsx
+++ b/app/app/components/ui/PageHeader.tsx
@@ -14,7 +14,7 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
     <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
       <div>
-        <h1 className="text-display-md text-foreground">{title}</h1>
+        <h1 className="page-heading">{title}</h1>
         {description && (
           <p className="mt-2 text-muted-foreground">{description}</p>
         )}

--- a/app/app/routes/dashboard._index.tsx
+++ b/app/app/routes/dashboard._index.tsx
@@ -816,7 +816,7 @@ export default function Dashboard({ loaderData, actionData }: Route.ComponentPro
   }, [editingEventId, upcomingEvents]);
 
   return (
-    <main className="dashboard-preview max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+    <main className="dashboard-preview page-main">
       <header
         className="mb-8 dashboard-section"
         style={{ '--section-delay': '20ms' } as CSSProperties}
@@ -1313,7 +1313,7 @@ export default function Dashboard({ loaderData, actionData }: Route.ComponentPro
 
 export function HydrateFallback() {
   return (
-    <main className="dashboard-preview max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+    <main className="dashboard-preview page-main">
       <div className="mb-8 card-shell p-8 animate-pulse">
         <div className="h-4 w-40 bg-muted rounded mb-4" />
         <div className="h-10 w-64 bg-muted rounded mb-3" />

--- a/app/app/routes/dashboard._index.tsx
+++ b/app/app/routes/dashboard._index.tsx
@@ -821,7 +821,7 @@ export default function Dashboard({ loaderData, actionData }: Route.ComponentPro
         className="mb-8 dashboard-section"
         style={{ '--section-delay': '20ms' } as CSSProperties}
       >
-        <h1 className="text-3xl sm:text-4xl font-display font-semibold text-foreground">
+        <h1 className="page-heading">
           Meatup Club
         </h1>
         <p className="mt-2 text-lg text-muted-foreground">
@@ -874,7 +874,7 @@ export default function Dashboard({ loaderData, actionData }: Route.ComponentPro
           <div className="flex items-center gap-4">
             <span className="icon-container-lg"><CalendarDaysIcon className="w-6 h-6" /></span>
             <div>
-              <h2 className="text-xl font-display font-semibold text-foreground">Upcoming Events</h2>
+              <h2 className="section-heading">Upcoming Events</h2>
               <p className="text-sm text-muted-foreground mt-1">
                 RSVP and see who's in.
               </p>
@@ -944,7 +944,7 @@ export default function Dashboard({ loaderData, actionData }: Route.ComponentPro
             <div className="flex items-center gap-4">
               <span className="icon-container-lg"><ClipboardDocumentCheckIcon className="w-6 h-6" /></span>
               <div>
-                <h2 className="text-xl font-display font-semibold text-foreground">
+                <h2 className="section-heading">
                   {activePoll.title}
                 </h2>
                 <p className="text-sm text-muted-foreground mt-1">
@@ -1037,7 +1037,7 @@ export default function Dashboard({ loaderData, actionData }: Route.ComponentPro
             <div className="flex items-center gap-4">
               <span className="icon-container-lg bg-muted"><ClipboardDocumentListIcon className="w-6 h-6" /></span>
               <div>
-                <h2 className="text-xl font-display font-semibold text-foreground">No Active Poll</h2>
+                <h2 className="section-heading">No Active Poll</h2>
                 <p className="text-sm text-muted-foreground mt-1">
                   {isAdmin
                     ? "Start a new poll to begin voting on the next meetup location and date."
@@ -1065,7 +1065,7 @@ export default function Dashboard({ loaderData, actionData }: Route.ComponentPro
           <div className="flex items-center gap-4">
             <span className="icon-container-lg"><BuildingStorefrontIcon className="w-6 h-6" /></span>
             <div>
-              <h2 className="text-xl font-display font-semibold text-foreground">Restaurants</h2>
+              <h2 className="section-heading">Restaurants</h2>
               <p className="text-sm text-muted-foreground mt-1">
                 The collection — select a row for details.
               </p>
@@ -1177,7 +1177,7 @@ export default function Dashboard({ loaderData, actionData }: Route.ComponentPro
         >
           <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
             <div>
-              <h2 className="text-xl font-display font-semibold text-foreground">Past Events</h2>
+              <h2 className="section-heading">Past Events</h2>
               <p className="text-sm text-muted-foreground mt-1">
                 Where the club has been.
               </p>
@@ -1229,7 +1229,7 @@ export default function Dashboard({ loaderData, actionData }: Route.ComponentPro
         >
           <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
             <div>
-              <h2 className="text-xl font-display font-semibold text-foreground">Past Polls</h2>
+              <h2 className="section-heading">Past Polls</h2>
               <p className="text-sm text-muted-foreground mt-1">
                 Recently closed polls and their winners.
               </p>
@@ -1276,7 +1276,7 @@ export default function Dashboard({ loaderData, actionData }: Route.ComponentPro
       >
         <div className="divider-accent mb-10" />
         <Card className="p-6 text-center">
-          <h3 className="text-xl font-display font-semibold text-foreground mb-4">
+          <h3 className="section-heading mb-4">
             Have feedback or found a bug?
           </h3>
           <div className="flex flex-wrap gap-3 justify-center">

--- a/app/app/routes/dashboard.about.tsx
+++ b/app/app/routes/dashboard.about.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import type { Route } from "./+types/dashboard.about";
 import type { ContentItem, Member } from "~/lib/types";
 import { requireActiveUser } from "../lib/auth.server";
@@ -42,12 +43,20 @@ export default function AboutPage({ loaderData }: Route.ComponentProps) {
 
   return (
     <main className="page-main">
-      <PageHeader
-        title="About Meatup.Club"
-        description="Everything you need to know about our quarterly steakhouse adventures"
-      />
+      <div
+        className="dashboard-section"
+        style={{ '--section-delay': '20ms' } as CSSProperties}
+      >
+        <PageHeader
+          title="About Meatup.Club"
+          description="Everything you need to know about our quarterly steakhouse adventures"
+        />
+      </div>
 
-      <section className="mb-12">
+      <section
+        className="mb-12 dashboard-section"
+        style={{ '--section-delay': '40ms' } as CSSProperties}
+      >
         <h2 className="section-heading mb-4">
           Members ({members.length})
         </h2>
@@ -77,7 +86,10 @@ export default function AboutPage({ loaderData }: Route.ComponentProps) {
         </div>
       </section>
 
-      <div className="space-y-8">
+      <div
+        className="space-y-8 dashboard-section"
+        style={{ '--section-delay': '150ms' } as CSSProperties}
+      >
         {content.map((item: ContentItem) => (
           <Card key={item.id}>
             <h2 className="section-heading mb-4 flex items-center gap-2">
@@ -111,12 +123,17 @@ export default function AboutPage({ loaderData }: Route.ComponentProps) {
         ))}
       </div>
 
-      <Alert variant="info" className="mt-8">
-        <h3 className="font-semibold mb-2">Questions or Suggestions?</h3>
-        <p className="text-sm">
-          Have ideas for improving Meatup.Club? Reach out to an admin or submit feedback through the dashboard.
-        </p>
-      </Alert>
+      <div
+        className="dashboard-section"
+        style={{ '--section-delay': '250ms' } as CSSProperties}
+      >
+        <Alert variant="info" className="mt-8">
+          <h3 className="font-semibold mb-2">Questions or Suggestions?</h3>
+          <p className="text-sm">
+            Have ideas for improving Meatup.Club? Reach out to an admin or submit feedback through the dashboard.
+          </p>
+        </Alert>
+      </div>
     </main>
   );
 }

--- a/app/app/routes/dashboard.about.tsx
+++ b/app/app/routes/dashboard.about.tsx
@@ -48,7 +48,7 @@ export default function AboutPage({ loaderData }: Route.ComponentProps) {
       />
 
       <section className="mb-12">
-        <h2 className="text-2xl font-bold text-foreground mb-4">
+        <h2 className="section-heading mb-4">
           Members ({members.length})
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-1">
@@ -80,7 +80,7 @@ export default function AboutPage({ loaderData }: Route.ComponentProps) {
       <div className="space-y-8">
         {content.map((item: ContentItem) => (
           <Card key={item.id}>
-            <h2 className="text-2xl font-bold text-foreground mb-4 flex items-center gap-2">
+            <h2 className="section-heading mb-4 flex items-center gap-2">
               <span className="w-6 h-6 text-accent">
                 {item.key === 'description' && <BookOpenIcon className="w-6 h-6" />}
                 {item.key === 'goals' && <RocketLaunchIcon className="w-6 h-6" />}

--- a/app/app/routes/dashboard.about.tsx
+++ b/app/app/routes/dashboard.about.tsx
@@ -41,7 +41,7 @@ export default function AboutPage({ loaderData }: Route.ComponentProps) {
   const { content, members } = loaderData;
 
   return (
-    <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <main className="page-main">
       <PageHeader
         title="About Meatup.Club"
         description="Everything you need to know about our quarterly steakhouse adventures"

--- a/app/app/routes/dashboard.admin._index.tsx
+++ b/app/app/routes/dashboard.admin._index.tsx
@@ -13,7 +13,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 export default function AdminPage() {
   return (
     <AdminLayout>
-    <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <main className="page-main">
       <div className="mb-8">
         <h1 className="text-3xl font-bold">Admin Panel</h1>
         <p className="text-muted-foreground mt-1">Manage events, polls, and members</p>
@@ -170,7 +170,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
 
   return (
     <AdminLayout>
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <main className="page-main">
         <Alert variant="error">
           <div className="space-y-3">
             <p className="font-semibold">{message}</p>

--- a/app/app/routes/dashboard.admin._index.tsx
+++ b/app/app/routes/dashboard.admin._index.tsx
@@ -15,7 +15,7 @@ export default function AdminPage() {
     <AdminLayout>
     <main className="page-main">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold">Admin Panel</h1>
+        <h1 className="page-heading">Admin Panel</h1>
         <p className="text-muted-foreground mt-1">Manage events, polls, and members</p>
       </div>
 

--- a/app/app/routes/dashboard.admin._index.tsx
+++ b/app/app/routes/dashboard.admin._index.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { Link, isRouteErrorResponse } from "react-router";
 import type { Route } from "./+types/dashboard.admin._index";
 import { requireAdmin } from "../lib/auth.server";
@@ -14,12 +15,18 @@ export default function AdminPage() {
   return (
     <AdminLayout>
     <main className="page-main">
-      <div className="mb-8">
+      <div
+        className="mb-8 dashboard-section"
+        style={{ '--section-delay': '20ms' } as CSSProperties}
+      >
         <h1 className="page-heading">Admin Panel</h1>
         <p className="text-muted-foreground mt-1">Manage events, polls, and members</p>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div
+        className="grid grid-cols-1 md:grid-cols-2 gap-6 dashboard-section"
+        style={{ '--section-delay': '40ms' } as CSSProperties}
+      >
         <Link to="/dashboard/admin/polls">
           <Card hover className="p-8">
             <div className="flex items-center gap-4 mb-4">
@@ -27,7 +34,7 @@ export default function AdminPage() {
                 <ClipboardDocumentCheckIcon className="w-8 h-8" />
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-foreground">Polls</h2>
+                <h2 className="section-heading">Polls</h2>
                 <p className="text-muted-foreground">Manage voting polls</p>
               </div>
             </div>
@@ -47,7 +54,7 @@ export default function AdminPage() {
                 <CalendarDaysIcon className="w-8 h-8" />
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-foreground">Events</h2>
+                <h2 className="section-heading">Events</h2>
                 <p className="text-muted-foreground">Manage meetup events</p>
               </div>
             </div>
@@ -67,7 +74,7 @@ export default function AdminPage() {
                 <UserGroupIcon className="w-8 h-8" />
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-foreground">Members</h2>
+                <h2 className="section-heading">Members</h2>
                 <p className="text-muted-foreground">Manage club members</p>
               </div>
             </div>
@@ -87,7 +94,7 @@ export default function AdminPage() {
                 📝
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-foreground">Content</h2>
+                <h2 className="section-heading">Content</h2>
                 <p className="text-muted-foreground">Edit site content</p>
               </div>
             </div>
@@ -107,7 +114,7 @@ export default function AdminPage() {
                 <EnvelopeIcon className="w-8 h-8" />
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-foreground">Email Templates</h2>
+                <h2 className="section-heading">Email Templates</h2>
                 <p className="text-muted-foreground">Manage invitation emails</p>
               </div>
             </div>
@@ -127,7 +134,7 @@ export default function AdminPage() {
                 📊
               </div>
               <div>
-                <h2 className="text-2xl font-bold text-foreground">Analytics</h2>
+                <h2 className="section-heading">Analytics</h2>
                 <p className="text-muted-foreground">Track user activity</p>
               </div>
             </div>
@@ -141,6 +148,10 @@ export default function AdminPage() {
         </Link>
       </div>
 
+      <div
+        className="dashboard-section"
+        style={{ '--section-delay': '150ms' } as CSSProperties}
+      >
       <Alert variant="info" className="mt-6">
         <h3 className="font-semibold mb-2 flex items-center gap-2"><WrenchScrewdriverIcon className="w-5 h-5" /> Maintenance Tools</h3>
         <Link
@@ -152,6 +163,7 @@ export default function AdminPage() {
           <span>→</span>
         </Link>
       </Alert>
+      </div>
     </main>
     </AdminLayout>
   );

--- a/app/app/routes/dashboard.admin.analytics.tsx
+++ b/app/app/routes/dashboard.admin.analytics.tsx
@@ -65,7 +65,7 @@ export default function AdminAnalyticsPage({ loaderData }: Route.ComponentProps)
 
   return (
     <AdminLayout>
-    <div className="max-w-7xl mx-auto">
+    <main className="page-main">
       <PageHeader
         title="User Analytics"
         description="Track user activity and engagement"
@@ -268,7 +268,7 @@ export default function AdminAnalyticsPage({ loaderData }: Route.ComponentProps)
           </div>
         </div>
       </Card>
-    </div>
+    </main>
     </AdminLayout>
   );
 }

--- a/app/app/routes/dashboard.admin.announcements.tsx
+++ b/app/app/routes/dashboard.admin.announcements.tsx
@@ -222,7 +222,7 @@ export default function AdminAnnouncementsPage({
 
   return (
     <AdminLayout>
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <main className="page-main">
         <PageHeader
           title="Member Announcements"
           description="Send a one-off email to all active members or a selected subset. Markdown is supported for both the preview and the outgoing email."

--- a/app/app/routes/dashboard.admin.content.tsx
+++ b/app/app/routes/dashboard.admin.content.tsx
@@ -90,7 +90,7 @@ export default function AdminContentPage({ loaderData, actionData }: Route.Compo
 
   return (
     <AdminLayout>
-    <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <main className="page-main">
       <PageHeader
         title="Site Content Management"
         description="Edit the club's description, goals, guidelines, and other information"

--- a/app/app/routes/dashboard.admin.email-templates.tsx
+++ b/app/app/routes/dashboard.admin.email-templates.tsx
@@ -191,7 +191,7 @@ export default function AdminEmailTemplatesPage({ loaderData, actionData }: Rout
 
   return (
     <AdminLayout>
-    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <main className="page-main">
       <PageHeader
         title="Email Templates"
         description={`Manage invitation email templates. Use ${'{{inviteeName}}'}, ${'{{inviterName}}'}, and ${'{{acceptLink}}'} as variables.`}

--- a/app/app/routes/dashboard.admin.events.tsx
+++ b/app/app/routes/dashboard.admin.events.tsx
@@ -865,7 +865,7 @@ export default function AdminEventsPage({ loaderData, actionData }: Route.Compon
 
   return (
     <AdminLayout>
-    <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <main className="page-main">
       <PageHeader
         title="Event Management"
         description="Create and manage meetup events"

--- a/app/app/routes/dashboard.admin.members.tsx
+++ b/app/app/routes/dashboard.admin.members.tsx
@@ -268,7 +268,7 @@ export default function AdminMembersPage({ loaderData, actionData }: Route.Compo
 
   return (
     <AdminLayout>
-    <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <main className="page-main">
       <PageHeader
         title="Member Management"
         description={`Total members: ${members.length}`}

--- a/app/app/routes/dashboard.admin.polls.tsx
+++ b/app/app/routes/dashboard.admin.polls.tsx
@@ -466,7 +466,7 @@ export default function AdminPollsPage({ loaderData, actionData }: Route.Compone
 
   return (
     <AdminLayout>
-    <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <main className="page-main">
       <PageHeader
         title="Poll Management"
         description="Manage voting polls and close with winners"

--- a/app/app/routes/dashboard.admin.refresh-restaurants.tsx
+++ b/app/app/routes/dashboard.admin.refresh-restaurants.tsx
@@ -110,7 +110,7 @@ export default function RefreshRestaurantsPage({ actionData }: Route.ComponentPr
 
   return (
     <AdminLayout>
-      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <main className="page-main">
         <Card className="p-8">
           <PageHeader title="Refresh Restaurant Metadata" />
 

--- a/app/app/routes/dashboard.admin.setup.tsx
+++ b/app/app/routes/dashboard.admin.setup.tsx
@@ -48,7 +48,7 @@ export default function AdminSetupPage({ actionData }: { actionData: SetupAction
 
   return (
     <AdminLayout>
-    <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <main className="page-main">
       <PageHeader
         title="System Setup"
         description="Configure external integrations and services"

--- a/app/app/routes/dashboard.profile.tsx
+++ b/app/app/routes/dashboard.profile.tsx
@@ -81,7 +81,7 @@ export default function ProfilePage({ loaderData, actionData }: Route.ComponentP
   const { user } = loaderData;
 
   return (
-    <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <main className="page-main">
       <PageHeader title="Profile & Settings" />
 
       {actionData?.success && (

--- a/app/app/routes/dashboard.profile.tsx
+++ b/app/app/routes/dashboard.profile.tsx
@@ -98,7 +98,7 @@ export default function ProfilePage({ loaderData, actionData }: Route.ComponentP
 
       {/* User Info */}
       <Card className="mb-8">
-        <h2 className="text-xl font-semibold text-foreground mb-4">Account Information</h2>
+        <h2 className="section-heading mb-4">Account Information</h2>
         <div className="flex items-center gap-4 mb-4">
           {user.picture && (
             <UserAvatar
@@ -123,7 +123,7 @@ export default function ProfilePage({ loaderData, actionData }: Route.ComponentP
 
       {/* Notification Preferences */}
       <Card>
-        <h2 className="text-xl font-semibold text-foreground mb-4">Email Notifications</h2>
+        <h2 className="section-heading mb-4">Email Notifications</h2>
         <p className="text-sm text-muted-foreground mb-6">
           Choose which email notifications you'd like to receive from Meatup.Club
         </p>
@@ -175,7 +175,7 @@ export default function ProfilePage({ loaderData, actionData }: Route.ComponentP
 
       {/* SMS Preferences */}
       <Card className="mt-8">
-        <h2 className="text-xl font-semibold text-foreground mb-4">SMS Reminders</h2>
+        <h2 className="section-heading mb-4">SMS Reminders</h2>
         <p className="text-sm text-muted-foreground mb-6">
           Get text reminders before each meetup. SMS is optional and not required to use
           Meatup.Club.

--- a/app/app/routes/dashboard.profile.tsx
+++ b/app/app/routes/dashboard.profile.tsx
@@ -97,8 +97,8 @@ export default function ProfilePage({ loaderData, actionData }: Route.ComponentP
       )}
 
       {/* User Info */}
+      <h2 className="section-heading mb-3">Account Information</h2>
       <Card className="mb-8">
-        <h2 className="section-heading mb-4">Account Information</h2>
         <div className="flex items-center gap-4 mb-4">
           {user.picture && (
             <UserAvatar
@@ -122,8 +122,8 @@ export default function ProfilePage({ loaderData, actionData }: Route.ComponentP
       </Card>
 
       {/* Notification Preferences */}
+      <h2 className="section-heading mb-3">Email Notifications</h2>
       <Card>
-        <h2 className="section-heading mb-4">Email Notifications</h2>
         <p className="text-sm text-muted-foreground mb-6">
           Choose which email notifications you'd like to receive from Meatup.Club
         </p>
@@ -174,8 +174,8 @@ export default function ProfilePage({ loaderData, actionData }: Route.ComponentP
       </Card>
 
       {/* SMS Preferences */}
-      <Card className="mt-8">
-        <h2 className="section-heading mb-4">SMS Reminders</h2>
+      <h2 className="section-heading mb-3 mt-8">SMS Reminders</h2>
+      <Card>
         <p className="text-sm text-muted-foreground mb-6">
           Get text reminders before each meetup. SMS is optional and not required to use
           Meatup.Club.

--- a/app/app/routes/privacy.tsx
+++ b/app/app/routes/privacy.tsx
@@ -2,8 +2,7 @@ import { Link } from "react-router";
 
 export default function PrivacyPage() {
   return (
-    <main className="min-h-screen bg-background px-6 py-12 sm:px-10 lg:px-16">
-      <div className="mx-auto max-w-3xl">
+    <main className="page-main">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-accent">
           Meatup.Club
         </p>
@@ -148,7 +147,6 @@ export default function PrivacyPage() {
           <Link to="/verification" className="text-sm font-medium text-accent hover:text-accent-strong">
             Verification
           </Link>
-        </div>
       </div>
     </main>
   );

--- a/app/app/routes/privacy.tsx
+++ b/app/app/routes/privacy.tsx
@@ -6,7 +6,7 @@ export default function PrivacyPage() {
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-accent">
           Meatup.Club
         </p>
-        <h1 className="mt-3 text-4xl font-bold tracking-tight text-foreground">
+        <h1 className="mt-3 page-heading">
           Privacy Policy & SMS Consent
         </h1>
         <p className="mt-3 text-sm text-muted-foreground">Last updated: February 25, 2026</p>
@@ -23,7 +23,7 @@ export default function PrivacyPage() {
 
         <div className="mt-10 space-y-8 text-muted-foreground">
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Overview</h2>
+            <h2 className="section-heading">Overview</h2>
             <p className="mt-3">
               Meatup.Club is a private dining club application used to coordinate member voting,
               RSVPs, and event reminders. It is operated by Jeffrey A Spahr, doing business as
@@ -33,7 +33,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Information We Collect</h2>
+            <h2 className="section-heading">Information We Collect</h2>
             <ul className="mt-3 list-disc space-y-2 pl-6">
               <li>Account details: name, email, and profile photo from Google OAuth.</li>
               <li>Club activity: poll votes, RSVPs, comments, and membership status.</li>
@@ -43,7 +43,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">How We Use Information</h2>
+            <h2 className="section-heading">How We Use Information</h2>
             <ul className="mt-3 list-disc space-y-2 pl-6">
               <li>Operate the club platform and member dashboard.</li>
               <li>Send event-related notifications by email and SMS (if opted in).</li>
@@ -52,7 +52,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">SMS Program Details</h2>
+            <h2 className="section-heading">SMS Program Details</h2>
             <ul className="mt-3 list-disc space-y-2 pl-6">
               <li>
                 <span className="font-medium text-foreground">Program name:</span> Meatup.Club
@@ -82,7 +82,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Proof of Consumer Consent</h2>
+            <h2 className="section-heading">Proof of Consumer Consent</h2>
             <p className="mt-3">
               Consumers provide SMS consent directly within the authenticated profile settings page.
               Public documentation of the opt-in flow and exact consent language is available at{" "}
@@ -117,7 +117,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Sharing & Vendors</h2>
+            <h2 className="section-heading">Sharing & Vendors</h2>
             <p className="mt-3">
               We do not sell personal information. We use service providers to operate the
               platform, including Google (authentication), Cloudflare (hosting/database), Resend
@@ -126,7 +126,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Contact</h2>
+            <h2 className="section-heading">Contact</h2>
             <p className="mt-3">
               Questions about privacy or SMS consent can be sent to{" "}
               <a

--- a/app/app/routes/sms-consent.tsx
+++ b/app/app/routes/sms-consent.tsx
@@ -2,8 +2,7 @@ import { Link } from "react-router";
 
 export default function SmsConsentPage() {
   return (
-    <main className="min-h-screen bg-background px-6 py-12 sm:px-10 lg:px-16">
-      <div className="mx-auto max-w-3xl">
+    <main className="page-main">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-accent">
           Meatup.Club
         </p>
@@ -88,7 +87,6 @@ export default function SmsConsentPage() {
           <Link to="/terms" className="font-medium text-accent hover:text-accent-strong">
             Terms
           </Link>
-        </div>
       </div>
     </main>
   );

--- a/app/app/routes/sms-consent.tsx
+++ b/app/app/routes/sms-consent.tsx
@@ -6,7 +6,7 @@ export default function SmsConsentPage() {
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-accent">
           Meatup.Club
         </p>
-        <h1 className="mt-3 text-4xl font-bold tracking-tight text-foreground">
+        <h1 className="mt-3 page-heading">
           SMS Consent & Opt-In
         </h1>
         <p className="mt-3 text-sm text-muted-foreground">Last updated: February 25, 2026</p>
@@ -23,7 +23,7 @@ export default function SmsConsentPage() {
 
         <div className="mt-10 space-y-8 text-muted-foreground">
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Program operator</h2>
+            <h2 className="section-heading">Program operator</h2>
             <p className="mt-3">
               This SMS program is operated by Jeffrey A Spahr, doing business as Meatup.Club, as a
               sole proprietor.
@@ -31,7 +31,7 @@ export default function SmsConsentPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">How Users Opt In</h2>
+            <h2 className="section-heading">How Users Opt In</h2>
             <ol className="mt-3 list-decimal space-y-2 pl-6">
               <li>Sign in to Meatup.Club.</li>
               <li>Go to Profile settings.</li>
@@ -49,7 +49,7 @@ export default function SmsConsentPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Program Details</h2>
+            <h2 className="section-heading">Program Details</h2>
             <ul className="mt-3 list-disc space-y-2 pl-6">
               <li>Purpose: event reminders and RSVP status updates only.</li>
               <li>Frequency: varies by event, typically low volume.</li>
@@ -63,7 +63,7 @@ export default function SmsConsentPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Contact</h2>
+            <h2 className="section-heading">Contact</h2>
             <p className="mt-3">
               Questions about SMS consent can be sent to{" "}
               <a

--- a/app/app/routes/terms.tsx
+++ b/app/app/routes/terms.tsx
@@ -6,7 +6,7 @@ export default function TermsPage() {
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-accent">
           Meatup.Club
         </p>
-        <h1 className="mt-3 text-4xl font-bold tracking-tight text-foreground">
+        <h1 className="mt-3 page-heading">
           Terms & Conditions
         </h1>
         <p className="mt-3 text-sm text-muted-foreground">Last updated: February 25, 2026</p>
@@ -23,7 +23,7 @@ export default function TermsPage() {
 
         <div className="mt-10 space-y-8 text-muted-foreground">
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Service Overview</h2>
+            <h2 className="section-heading">Service Overview</h2>
             <p className="mt-3">
               Meatup.Club is an invite-only application used to coordinate dining events,
               member RSVPs, and operational reminders. The service is operated by Jeffrey A Spahr,
@@ -32,7 +32,7 @@ export default function TermsPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Eligibility & Accounts</h2>
+            <h2 className="section-heading">Eligibility & Accounts</h2>
             <ul className="mt-3 list-disc space-y-2 pl-6">
               <li>Access is limited to invited members.</li>
               <li>Members are responsible for account security and accurate contact details.</li>
@@ -41,7 +41,7 @@ export default function TermsPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">SMS Program Terms</h2>
+            <h2 className="section-heading">SMS Program Terms</h2>
             <ul className="mt-3 list-disc space-y-2 pl-6">
               <li>
                 Program: Meatup.Club event reminders and RSVP updates (no marketing/promotional
@@ -69,7 +69,7 @@ export default function TermsPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Privacy</h2>
+            <h2 className="section-heading">Privacy</h2>
             <p className="mt-3">
               Use of the service is also governed by the Privacy Policy at{" "}
               <Link
@@ -83,7 +83,7 @@ export default function TermsPage() {
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-foreground">Contact</h2>
+            <h2 className="section-heading">Contact</h2>
             <p className="mt-3">
               Questions about these terms can be sent to{" "}
               <a

--- a/app/app/routes/terms.tsx
+++ b/app/app/routes/terms.tsx
@@ -2,8 +2,7 @@ import { Link } from "react-router";
 
 export default function TermsPage() {
   return (
-    <main className="min-h-screen bg-background px-6 py-12 sm:px-10 lg:px-16">
-      <div className="mx-auto max-w-3xl">
+    <main className="page-main">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-accent">
           Meatup.Club
         </p>
@@ -105,7 +104,6 @@ export default function TermsPage() {
           <Link to="/verification" className="text-sm font-medium text-accent hover:text-accent-strong">
             Verification
           </Link>
-        </div>
       </div>
     </main>
   );

--- a/app/app/routes/verification.tsx
+++ b/app/app/routes/verification.tsx
@@ -29,7 +29,7 @@ export default function VerificationPage() {
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">
             Meatup.Club
           </p>
-          <h1 className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+          <h1 className="mt-4 page-heading">
             Business Verification & SMS Compliance
           </h1>
           <p className="mt-4 max-w-3xl text-base leading-7 text-muted-foreground sm:text-lg">
@@ -51,7 +51,7 @@ export default function VerificationPage() {
 
         <div className="mt-8 grid gap-6 lg:grid-cols-[1.35fr_1fr]">
           <section className="rounded-[2rem] border border-border bg-card px-6 py-7 shadow-sm sm:px-8">
-            <h2 className="text-2xl font-semibold text-foreground">Business identity</h2>
+            <h2 className="section-heading">Business identity</h2>
             <p className="mt-3 text-sm leading-6 text-muted-foreground">
               Meatup.Club is an invite-only dining club application used to coordinate member
               voting, RSVPs, and event reminders. The service is operated by Jeffrey A Spahr,
@@ -68,7 +68,7 @@ export default function VerificationPage() {
           </section>
 
           <section className="rounded-[2rem] border border-border bg-card px-6 py-7 shadow-sm sm:px-8">
-            <h2 className="text-2xl font-semibold text-foreground">Public review links</h2>
+            <h2 className="section-heading">Public review links</h2>
             <p className="mt-3 text-sm leading-6 text-muted-foreground">
               All of the following pages are public and available without authentication.
             </p>
@@ -83,7 +83,7 @@ export default function VerificationPage() {
 
         <div className="mt-8 grid gap-6 lg:grid-cols-2">
           <section className="rounded-[2rem] border border-border bg-card px-6 py-7 shadow-sm sm:px-8">
-            <h2 className="text-2xl font-semibold text-foreground">SMS program details</h2>
+            <h2 className="section-heading">SMS program details</h2>
             <ul className="mt-5 space-y-3 text-sm leading-6 text-muted-foreground">
               <li>
                 <span className="font-semibold text-foreground">Program name:</span> Meatup.Club
@@ -121,7 +121,7 @@ export default function VerificationPage() {
           </section>
 
           <section className="rounded-[2rem] border border-border bg-card px-6 py-7 shadow-sm sm:px-8">
-            <h2 className="text-2xl font-semibold text-foreground">Authentication boundary</h2>
+            <h2 className="section-heading">Authentication boundary</h2>
             <p className="mt-3 text-sm leading-6 text-muted-foreground">
               Meatup.Club is invite-only, so the member dashboard and profile settings require
               login. That authentication gate exists to protect member data, not to hide business
@@ -139,7 +139,7 @@ export default function VerificationPage() {
         </div>
 
         <section className="mt-8 rounded-[2rem] border border-border bg-card px-6 py-7 shadow-sm sm:px-8">
-          <h2 className="text-2xl font-semibold text-foreground">How consent is collected</h2>
+          <h2 className="section-heading">How consent is collected</h2>
           <ol className="mt-5 list-decimal space-y-3 pl-6 text-sm leading-6 text-muted-foreground">
             <li>Members sign in to their invite-only Meatup.Club account.</li>
             <li>Members open profile settings and enter a valid US mobile number.</li>

--- a/app/app/routes/verification.tsx
+++ b/app/app/routes/verification.tsx
@@ -24,8 +24,7 @@ function PublicLink({ href }: { href: string }) {
 
 export default function VerificationPage() {
   return (
-    <main className="min-h-screen bg-background px-6 py-12 sm:px-10 lg:px-16">
-      <div className="mx-auto max-w-5xl">
+    <main className="page-main">
         <div className="rounded-[2rem] border border-accent/20 bg-accent/[0.04] px-6 py-8 shadow-sm sm:px-8">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">
             Meatup.Club
@@ -220,7 +219,6 @@ export default function VerificationPage() {
           <Link to="/sms-consent" className="font-medium text-accent hover:text-accent-strong">
             SMS Consent
           </Link>
-        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

Closes #155.

Centralizes page width, padding, and heading styles into CSS classes so future style adjustments are a single edit instead of a sweep across every route file.

- New classes in \`app.css\`: \`.page-main\`, \`.page-heading\`, \`.section-heading\`, \`.page-section\` (raw CSS, matching the existing \`.card-shell\` / \`.btn-primary\` convention)
- Every \`<main>\` across dashboard, admin, and public/legal pages uses \`.page-main\` (1152px / max-w-6xl, standard padding)
- \`PageHeader\` h1 uses \`.page-heading\`; page-level h2s use \`.section-heading\`
- About + Admin home gain the same staggered fade-in cadence Dashboard home already has
- Profile's three section titles lift outside their cards (the simple-section pattern); Dashboard home / About / Admin home keep their icon+toolbar header strips inside cards (intentional — those are coherent units)
- Legal pages (terms / privacy / sms-consent / verification) restructured to put the width constraint on \`<main>\` directly
- New \"Page layout conventions\" section in \`CLAUDE.md\` documents the rules

## Visual changes you'll notice

- Dashboard home: 1280px → 1152px width, py-10 → py-12 padding
- Profile / refresh-restaurants / setup: 896px → 1152px (wider)
- Email-templates / analytics: 1280px → 1152px
- Legal pages: 768px → 1152px (per discussion — these are not in the normal user journey)
- Section h2s on Dashboard home grow from text-xl semibold to text-2xl bold
- Section h2s on legal pages grow size + weight similarly

## Out of scope (option-3 follow-up)

Card padding defaults, grid gaps, and ad-hoc icon containers (e.g., Admin home's \`w-16 h-16 rounded-full bg-accent\` divs) are tracked in a separate follow-up — those benefit from broader Tailwind-cluster extraction with visual review.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run test:run\` — 557/557 pass
- [ ] Dashboard home renders at 6xl, fade-in still smooth, sections don't cramp
- [ ] About: page-load fade-in plays through header → Members → content → Alert
- [ ] Admin home: page-load fade-in plays through header → grid → Alert
- [ ] Profile: section titles sit above cards with mb-3
- [ ] Legal pages render at 6xl with correct h1/h2 sizes
- [ ] Email-templates and analytics layouts hold at the narrower width

🤖 Generated with [Claude Code](https://claude.com/claude-code)