### PR TITLE
Replace AGENTS.md existing-failures rule with scoped principle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,7 @@ Page-level layout decisions are centralized in `app/app/app.css`. Do not reintro
 ## Important Notes
 
 - This repo has historically accumulated stale agent notes. Verify claims against the live code before preserving them.
-- Do not assume existing type or test failures are acceptable. Run the relevant verification and record any inability to verify.
+- Do not chase TS or test errors unrelated to your change. If the root cause is in scope for what you are doing, fix it; otherwise leave it as-is and call it out in the PR description so reviewers can decide.
 - Cloudflare cache purging requires a zone ID, not an account ID.
 - Restaurants are global records; poll-specific voting is represented by join/vote tables and uniqueness constraints.
 - Voting and admin mutation flows commonly dispatch through `_action`; keep action names and response shapes consistent with nearby routes.


### PR DESCRIPTION
## Summary
Follow-up to #178. Replaces the new line in `AGENTS.md` under **Important Notes** that read:

> Do not assume existing type or test failures are acceptable. Run the relevant verification and record any inability to verify.

with:

> Do not chase TS or test errors unrelated to your change. If the root cause is in scope for what you are doing, fix it; otherwise leave it as-is and call it out in the PR description so reviewers can decide.

## Why
The line introduced in #178 doesn't give a usable behavioral signal — it neither tells an agent to fix unrelated noise nor to leave it. It also implicitly contradicts the prior `CLAUDE.md` "Pre-existing TS issues" inventory it replaced (which was itself drift-prone, so dropping the inventory was correct). The replacement is a scoping rule rather than a count: it tells an agent what to do with errors they didn't introduce, and routes the decision through the PR description so reviewers stay in the loop.

## Test plan
- [x] Docs-only change; no app tests run.
- [x] `git diff` is one line in `AGENTS.md`.
- [x] `CLAUDE.md` symlink still resolves: `readlink CLAUDE.md` → `AGENTS.md`.